### PR TITLE
Add BWB Wing-Body Junction Spar diagram

### DIFF
--- a/AS/M/PAX/BW/Q1H/README.md
+++ b/AS/M/PAX/BW/Q1H/README.md
@@ -469,3 +469,37 @@ The hydraulic system of the AMPEL360 BWB-Q100 is designed to meet the stringent 
   - Test the operation of hydraulic pumps and actuators.
 
 For a comprehensive technical specification of the hydraulic system, refer to the [Hydraulic System Specification Document](./hydraulic-system-specification.md).
+
+---
+
+## BWB Wing-Body Junction Spar
+
+### Top View Diagram
+
+WING OUTBOARD       WING-BODY JUNCTION       WING OUTBOARD
+┌───────────────┬═══════════════════┬───────────────┐
+│               │ ╔════╗            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│---------------┼══════╩════╩══════─┼---------------│
+│<-- WING -->   │<-- SPAR ZONE -->  │<-- WING -->   │
+│               │   (FUSELAGE)      │               │
+└───────────────┴═══════════════════┴───────────────┘
+
+### Legend
+- "═"      Spar cap/flange  
+- "║║"     Main spar web  
+- "╔════╗" Reinforced junction  
+- "●"      Fastener  
+- "◉"      Quantum sensor
+
+### Front / Side View
+
+[╔═══════╗]    (Reinforced spar/junction module cross-section)
+
+### Section A-A
+
+[╠═╬═╬═╬═╣]   (Spar cap/flange with web and fastener/sensor integration)

--- a/images/sample/drw.md
+++ b/images/sample/drw.md
@@ -58,3 +58,34 @@ This component incorporates several quantum-enhanced design features:
 4. **Material Selection**: Advanced aluminum-lithium alloy selected for primary structure with titanium reinforcements at high-stress concentration areas.
 5. **Testing Program**: Component has undergone static testing to 150% of limit load and fatigue testing equivalent to 180,000 flight cycles (2× design life).
 
+## BWB Wing-Body Junction Spar
+
+### Top View Diagram
+
+WING OUTBOARD       WING-BODY JUNCTION       WING OUTBOARD
+┌───────────────┬═══════════════════┬───────────────┐
+│               │ ╔════╗            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│               │ ║    ║            │               │
+│---------------┼══════╩════╩══════─┼---------------│
+│<-- WING -->   │<-- SPAR ZONE -->  │<-- WING -->   │
+│               │   (FUSELAGE)      │               │
+└───────────────┴═══════════════════┴───────────────┘
+
+### Legend
+- "═"      Spar cap/flange  
+- "║║"     Main spar web  
+- "╔════╗" Reinforced junction  
+- "●"      Fastener  
+- "◉"      Quantum sensor
+
+### Front / Side View
+
+[╔═══════╗]    (Reinforced spar/junction module cross-section)
+
+### Section A-A
+
+[╠═╬═╬═╬═╣]   (Spar cap/flange with web and fastener/sensor integration)


### PR DESCRIPTION
Add a new section for the BWB Wing-Body Junction Spar in the README and images/sample/drw.md files.

* **README.md**
  - Add a new section for the BWB Wing-Body Junction Spar.
  - Include the top view diagram and legend.
  - Add the front/side and section A-A diagrams.

* **images/sample/drw.md**
  - Add the top view, front/side, and section A-A diagrams.
  - Include the legend for the diagrams.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Gaia-Q-Air/assets/pull/7?shareId=4efe421f-96e3-4baf-b54d-32579b352de8).